### PR TITLE
add CURLOPT_SAFE_UPLOAD

### DIFF
--- a/Akismet.php
+++ b/Akismet.php
@@ -110,6 +110,7 @@ class Akismet
         $options[CURLOPT_TIMEOUT] = (int) $this->getTimeOut();
         $options[CURLOPT_POST] = true;
         $options[CURLOPT_POSTFIELDS] = $aParameters;
+        $options[CURLOPT_SAFE_UPLOAD] = true;
 
         // speed up things, use HTTP 1.0
         $options[CURLOPT_HTTP_VERSION] = CURL_HTTP_VERSION_1_0;

--- a/Akismet.php
+++ b/Akismet.php
@@ -112,7 +112,7 @@ class Akismet
         $options[CURLOPT_POSTFIELDS] = $aParameters;
         if (defined('CURLOPT_SAFE_UPLOAD')) {
             $options[CURLOPT_SAFE_UPLOAD] = true;
-        }]
+        }
 
         // speed up things, use HTTP 1.0
         $options[CURLOPT_HTTP_VERSION] = CURL_HTTP_VERSION_1_0;

--- a/Akismet.php
+++ b/Akismet.php
@@ -110,7 +110,9 @@ class Akismet
         $options[CURLOPT_TIMEOUT] = (int) $this->getTimeOut();
         $options[CURLOPT_POST] = true;
         $options[CURLOPT_POSTFIELDS] = $aParameters;
-        $options[CURLOPT_SAFE_UPLOAD] = true;
+        if (defined('CURLOPT_SAFE_UPLOAD')) {
+            $options[CURLOPT_SAFE_UPLOAD] = true;
+        }]
 
         // speed up things, use HTTP 1.0
         $options[CURLOPT_HTTP_VERSION] = CURL_HTTP_VERSION_1_0;


### PR DESCRIPTION
If comments, or other fields which will sent to Akismet server, start with `@`, the cURL will throw an error which says "couldn't open file blahblah".

[In PHP 5.5](http://php.net/manual/en/function.curl-setopt.php), there's a new option called `CURLOPT_SAFE_UPLOAD`, which can disable this feature.
