### PR TITLE
Fix loose comparision regression for PHP 8

### DIFF
--- a/Akismet.php
+++ b/Akismet.php
@@ -156,7 +156,9 @@ class Akismet
         }
 
         // error?
-        if ($errorNumber != '') throw new Exception($errorMessage, $errorNumber);
+        if ((int)$errorNumber > 0) {
+            throw new Exception($errorMessage, $errorNumber);
+        }
 
         // return
         return $response;


### PR DESCRIPTION
In PHP 8.0, loose type checks are handled differently as compared with PHP 7.4 and lower.

Therefor the following will return an exception, which causes the `isSpam` method to always return true.
The given fix adds compatibility with PHP 8.

```php
$errorNumber = 0;
if ($errorNumber != '') throw new Exception($errorMessage, $errorNumber);
```